### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/smbetray.py
+++ b/smbetray.py
@@ -100,11 +100,11 @@ class CredFileWatcher(Thread):
 							try:
 								self.poppedCredsDB[hash(popped)] = copy.deepcopy(popped)
 								logging.info("[CredFileWatcher] Loaded creds of " + popped.domain + "/" + popped.username)
-							except Exception, e:
+							except Exception as e:
 								logging.error("[CredFileWatcher::watch] " + str(e))
 								pass
 							self.poppedCredsDB_Lock.release()
-					except Exception, e:
+					except Exception as e:
 						logging.error("[CredFileWatcher::watch] " + str(e))
 						continue
 			time.sleep(.5)
@@ -164,7 +164,7 @@ class SMBetray(ebcLib.MiTMModule):
 				self.CLT_MESSAGE_LENGTH 		= raw.length + 4
 				# Don't return a response, thus we hold off passing the request to the server
 				return
-		except Exception, e:
+		except Exception as e:
 			logging.debug("[SMBetray::parseClientRequest] " + str(e) + " " + traceback.format_exc())
 			return request
 
@@ -210,7 +210,7 @@ class SMBetray(ebcLib.MiTMModule):
 				self.SRV_MESSAGE_LENGTH 		= raw.length + 4
 				# Don't return a response, thus we hold off replying to the client
 				return
-		except Exception, e:
+		except Exception as e:
 			logging.debug("[SMBetray::parseServerResponse] " + str(e) + " " + traceback.format_exc())
 			return response
 
@@ -386,7 +386,7 @@ def runAttack(config):
 			z.join(0)
 		if(fileWatcherThread != None):
 			fileWatcherThread.join(0)
-	except Exception, e:
+	except Exception as e:
 		m = logging.error(str(traceback.format_exc()))
 		logging.error("Error: " + str(m))
 if __name__ == "__main__":


### PR DESCRIPTION
Python 3 treats old style exceptions as syntax errors.  Similar changes are required to other files as well...

[flake8](http://flake8.pycqa.org) testing of https://github.com/quickbreach/SMBetray on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
/home/travis/virtualenv/python3.7.0/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
./smbetray.py:103:24: E999 SyntaxError: invalid syntax
							except Exception, e:
                       ^
./lib/ebcLib.py:426:20: E999 SyntaxError: invalid syntax
			except Exception, e:
                   ^
./lib/K2TKerb.py:52:25: E999 SyntaxError: invalid syntax
						except PyAsn1Error, e:
                        ^
./lib/SMB1_Lib.py:106:19: E999 SyntaxError: invalid syntax
		except Exception, e:
                  ^
./lib/SMB2_Lib.py:158:19: E999 SyntaxError: invalid syntax
		except Exception, e:
                  ^
./lib/SMB_Core.py:255:19: E999 SyntaxError: invalid syntax
		except Exception, e:
                  ^
6     E999 SyntaxError: invalid syntax
6
```